### PR TITLE
fix: preserve task duration when drag is clamped to earliestStart

### DIFF
--- a/src/components/gantt/TaskBar.tsx
+++ b/src/components/gantt/TaskBar.tsx
@@ -82,14 +82,18 @@ export default function TaskBar({
         let newStartStr = formatDate(newStart);
 
         // Clamp to earliest start constraint
+        let clampedDx = dx;
         if (earliestStart && newStartStr < earliestStart) {
           newStartStr = earliestStart;
           newStart = parseISO(earliestStart);
+          // Recompute the effective dx so end shifts by the same clamped amount
+          clampedDx = dateToXCollapsed(earliestStart, timelineStart, colWidth, zoom, collapseWeekends)
+            - dateToXCollapsed(dragRef.current.origStartDate, timelineStart, colWidth, zoom, collapseWeekends);
         }
 
-        // Shift end by same pixel delta as start to preserve visual width
+        // Shift end by same (possibly clamped) pixel delta as start to preserve visual width
         const newEnd = xToDateCollapsed(
-          dateToXCollapsed(dragRef.current.origEndDate, timelineStart, colWidth, zoom, collapseWeekends) + dx,
+          dateToXCollapsed(dragRef.current.origEndDate, timelineStart, colWidth, zoom, collapseWeekends) + clampedDx,
           timelineStart, colWidth, zoom, collapseWeekends
         );
         const newEndStr = formatDate(newEnd);

--- a/src/utils/__tests__/dateUtils.test.ts
+++ b/src/utils/__tests__/dateUtils.test.ts
@@ -109,6 +109,97 @@ describe('dateUtils', () => {
     });
   });
 
+  describe('earliestStart clamp must preserve task duration', () => {
+    const timelineStart = new Date('2026-03-02'); // Monday
+    const colWidth = 36;
+    const zoom = 'day' as const;
+    const collapseWeekends = false;
+
+    /**
+     * Simulates the buggy move handler: start is clamped to earliestStart,
+     * but end uses the unclamped dx, causing the task to shrink.
+     */
+    function simulateBuggyDrag(
+      origStart: string, origEnd: string, dxColumns: number, earliestStart: string
+    ) {
+      const dx = dxColumns * colWidth;
+      const origStartX = dateToXCollapsed(origStart, timelineStart, colWidth, zoom, collapseWeekends);
+      const origEndX = dateToXCollapsed(origEnd, timelineStart, colWidth, zoom, collapseWeekends);
+
+      // Compute new start, then clamp
+      let newStart = formatDate(xToDateCollapsed(origStartX + dx, timelineStart, colWidth, zoom, collapseWeekends));
+      if (newStart < earliestStart) {
+        newStart = earliestStart;
+      }
+
+      // Bug: end uses unclamped dx
+      const newEnd = formatDate(xToDateCollapsed(origEndX + dx, timelineStart, colWidth, zoom, collapseWeekends));
+
+      return { newStart, newEnd };
+    }
+
+    /**
+     * Simulates the fixed move handler: when start is clamped, the clamped dx
+     * is applied to end as well, preserving task duration.
+     */
+    function simulateFixedDrag(
+      origStart: string, origEnd: string, dxColumns: number, earliestStart: string
+    ) {
+      const dx = dxColumns * colWidth;
+      const origStartX = dateToXCollapsed(origStart, timelineStart, colWidth, zoom, collapseWeekends);
+      const origEndX = dateToXCollapsed(origEnd, timelineStart, colWidth, zoom, collapseWeekends);
+
+      // Compute new start, then clamp
+      let newStartX = origStartX + dx;
+      let newStart = formatDate(xToDateCollapsed(newStartX, timelineStart, colWidth, zoom, collapseWeekends));
+      if (newStart < earliestStart) {
+        newStart = earliestStart;
+        newStartX = dateToXCollapsed(earliestStart, timelineStart, colWidth, zoom, collapseWeekends);
+      }
+
+      // Fixed: use clamped dx for end
+      const clampedDx = newStartX - origStartX;
+      const newEnd = formatDate(xToDateCollapsed(origEndX + clampedDx, timelineStart, colWidth, zoom, collapseWeekends));
+
+      return { newStart, newEnd };
+    }
+
+    it('buggy handler shrinks task when dragged before earliestStart', () => {
+      // Task: Mar 10 (Tue) - Mar 13 (Fri), duration = 3 days
+      // earliestStart: Mar 9 (Mon)
+      // Drag left by 3 columns (trying to move to Mar 7)
+      // Start clamps to Mar 9, but end moves to Mar 10 with unclamped dx
+      // Duration shrinks from 3 to 1 -- this is the bug
+      const { newStart, newEnd } = simulateBuggyDrag('2026-03-10', '2026-03-13', -3, '2026-03-09');
+      expect(newStart).toBe('2026-03-09');
+      // Bug: end moved by -3 days instead of the clamped -1 day
+      const origDuration = daysBetween('2026-03-10', '2026-03-13');
+      const newDuration = daysBetween(newStart, newEnd);
+      expect(newDuration).toBeLessThan(origDuration); // confirms the bug
+    });
+
+    it('fixed handler preserves duration when dragged before earliestStart', () => {
+      // Same scenario: task Mar 10-13, earliestStart Mar 9, drag -3 cols
+      const { newStart, newEnd } = simulateFixedDrag('2026-03-10', '2026-03-13', -3, '2026-03-09');
+      expect(newStart).toBe('2026-03-09');
+      // Fixed: duration is preserved
+      const origDuration = daysBetween('2026-03-10', '2026-03-13');
+      const newDuration = daysBetween(newStart, newEnd);
+      expect(newDuration).toBe(origDuration);
+    });
+
+    it('fixed handler allows normal drag when not hitting earliestStart', () => {
+      // Task: Mar 12 - Mar 15, earliestStart: Mar 9, drag left by 1
+      // No clamping needed, should work normally
+      const { newStart, newEnd } = simulateFixedDrag('2026-03-12', '2026-03-15', -1, '2026-03-09');
+      expect(newStart).toBe('2026-03-11');
+      expect(newEnd).toBe('2026-03-14');
+      const origDuration = daysBetween('2026-03-12', '2026-03-15');
+      const newDuration = daysBetween(newStart, newEnd);
+      expect(newDuration).toBe(origDuration);
+    });
+  });
+
   describe('move-drag must preserve visual width with collapsed weekends', () => {
     const timelineStart = new Date('2026-03-02'); // Monday
     const colWidth = 36;


### PR DESCRIPTION
## Summary

Fixes a bug where dragging a task before its `earliestStart` constraint causes the duration to shrink. When the start date is clamped to `earliestStart`, the end date was still shifted by the unclamped pixel delta, causing start to be pinned while end kept moving left.

**Fix:** When `earliestStart` clamps the start, compute `clampedDx` (the actual pixel delta applied to start) and use it for end too, preserving visual width.

## Test plan

- [x] Test: buggy handler shrinks task when dragged before earliestStart (confirms the bug exists)
- [x] Test: fixed handler preserves duration when clamped
- [x] Test: normal drag (no clamping) still works
- [x] All existing drag/duration tests pass
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` passes
- [x] `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)