### PR TITLE
docs: add docker-compose.override.example.yml

### DIFF
--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -1,0 +1,11 @@
+# Local overrides for docker-compose.yml
+# Copy to docker-compose.override.yml and uncomment what you need.
+# docker-compose.override.yml is gitignored — it won't be committed.
+
+# services:
+#   dev:
+#     volumes:
+#       # Personal Claude Code preferences — loaded as global context for all projects.
+#       # Create ~/.claude/CLAUDE.md on your host with your dev preferences
+#       # (formatting, tool choices, workflow habits, etc.).
+#       - ~/.claude/CLAUDE.md:/home/node/.claude/CLAUDE.md:ro


### PR DESCRIPTION
## Summary

- Adds `docker-compose.override.example.yml` as a reference for local Docker Compose overrides
- Shows how to mount `~/.claude/CLAUDE.md` into the dev container so personal Claude Code preferences are available inside the container
- All entries are commented out by default — users copy to `docker-compose.override.yml` and uncomment as needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)