### PR TITLE
docs: add claude config mount to docker-compose override

### DIFF
--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -12,6 +12,8 @@ services:
       - ~/.gitconfig:/home/node/.gitconfig:ro
       # Share SSH keys for GitHub push/pull
       - ~/.ssh:/home/node/.ssh:ro
+      # Uncomment the following to use your local claude file for development
+      # - ~/.claude/CLAUDE.md:/home/node/.claude/CLAUDE.md:ro
       # Uncomment the following for Google Cloud auth (requires gcloud target above):
       # - ~/.config/gcloud:/home/node/.config/gcloud-host:ro
       # - gcloud-config:/home/node/.config/gcloud


### PR DESCRIPTION
## Summary
- Adds a commented-out volume mount for `~/.claude/CLAUDE.md` to `docker-compose.override.yml.example`
- Allows users to share their local Claude configuration with the dev container

## Test plan
- [ ] Verify `docker-compose.override.yml.example` has correct syntax
- [ ] Uncomment the mount line and confirm the container starts with the config available

🤖 Generated with [Claude Code](https://claude.com/claude-code)