### PR TITLE
docs: add safe worktree cleanup procedure

### DIFF
--- a/.claude/worktrees/CLAUDE.md
+++ b/.claude/worktrees/CLAUDE.md
@@ -20,5 +20,9 @@ It does NOT apply to CI/workflow agents.
 
 ## Worktree Lifecycle
 - You are working in a worktree. All git operations (commit, push, rebase) happen here.
-- Clean up when done: `cd /workspace && git worktree remove /workspace/.claude/worktrees/<name>`
 - If you find stale worktrees from crashed agents: `git worktree prune`
+- **Clean up when done (follow this exact order):**
+  1. Run `cd /workspace` as a **standalone Bash call** (not chained with `&&`)
+  2. Then in a **separate** Bash call: `git worktree remove /workspace/.claude/worktrees/<name>`
+  3. Then: `git branch -d <branch>` if the branch still exists
+  - **Why separate calls**: If `cd` is chained with `&&` and a later command fails, the Bash tool does not persist the directory change. The CWD remains pointed at the deleted worktree and all subsequent Bash calls fail — this is unrecoverable in the current session.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Use Grep/Glob/Read for: string literals, config keys, file discovery, understand
   - Create: `git worktree add /workspace/.claude/worktrees/<name> -b <branch>`
   - Work entirely within that directory — all git operations (commit, push) happen there
   - `/workspace` must always stay on `main` — it is the shared base for all worktrees
-  - **Clean up when done** (mandatory): `cd /workspace && git worktree remove /workspace/.claude/worktrees/<name>` — stale worktrees leak disk and block branch deletion
+  - **Clean up when done** (mandatory): see `.claude/worktrees/CLAUDE.md` for the exact cleanup procedure — stale worktrees leak disk and block branch deletion
 - Do NOT add features, refactoring, or "improvements" beyond what was requested.
 - Write failing tests before implementation when feasible (unit, integration — not E2E requiring deployment). Let the test define the expected behavior, then make it pass.
 - Rebase on main regularly during development (`git fetch origin && git rebase origin/main`). Always rebase and re-verify before creating a PR — the branch must pass against current HEAD, not a stale base.


### PR DESCRIPTION
## Summary

- Updated `CLAUDE.md` to reference `.claude/worktrees/CLAUDE.md` for the detailed worktree cleanup procedure
- Added `.claude/worktrees/CLAUDE.md` with a 3-step safe cleanup process: (1) cd to /workspace, (2) remove the worktree, (3) delete the branch
- The key insight: `cd` and `git worktree remove` must be separate Bash tool calls because if they are chained with `&&` and removal fails, the directory change is not persisted, leaving CWD pointed at a deleted worktree — which is unrecoverable

🤖 Generated with [Claude Code](https://claude.com/claude-code)