### PR TITLE
docs: add issue template instructions to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,10 @@ When working from a GitHub issue (via `agent-ready` label or manual assignment):
 - Write `.agent-summary.md` explaining where you got stuck.
 - The PR will be created even with partial work — human reviewers can help.
 
+**Creating Issues:**
+- When asked to create a GitHub issue, use the template in `.github/ISSUE_TEMPLATE/agent-task.yml` via `gh issue create --template agent-task.yml`.
+- Fill in all required fields: Task Summary, Acceptance Criteria, Scope Boundaries, and Estimated Complexity.
+
 ## Context Conservation
 - Commit early and often — progress survives crashes and context loss.
 - On restart, read `claude-progress.txt` first and check `git log --oneline -10`.


### PR DESCRIPTION
## Summary
- Adds a **Creating Issues** subsection to the Single-Agent Issue Workflow in CLAUDE.md
- Instructs agents to use `.github/ISSUE_TEMPLATE/agent-task.yml` via `gh issue create --template agent-task.yml`
- Ensures all required template fields (Task Summary, Acceptance Criteria, Scope Boundaries, Complexity) are filled in

## Test plan
- [ ] Verify CLAUDE.md renders correctly
- [ ] Confirm agents pick up the new instructions when creating issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)