### PR TITLE
refactor: merge/validate/PR operations use dedicated worktree

### DIFF
--- a/.claude/skills/multi-agent-orchestration/SKILL.md
+++ b/.claude/skills/multi-agent-orchestration/SKILL.md
@@ -34,12 +34,13 @@ Phase launch configuration is defined in `docs/prompts/<phaseN>/launch-config.ya
 
 ## Worktree Isolation (Critical)
 Each agent MUST run in its own git worktree. `/workspace` stays on `main` always.
-- `launch-phase.sh` handles this automatically via `setup_worktree()`
+- **Agent worktrees**: `setup_worktree()` creates per-group worktrees at `/workspace/.claude/worktrees/<phase>-<group>`
+- **Merge worktree**: `setup_merge_worktree()` creates a long-lived worktree at `/workspace/.claude/worktrees/<phase>-merge` for all merge/validate/PR operations. It persists across stages and is cleaned up after PR creation.
 - Manually-launched agents must create their own: `git worktree add /workspace/.claude/worktrees/<name> -b <branch>`
 - NEVER `git checkout` or `git switch` in `/workspace` — this breaks every other agent sharing the filesystem
 - All git operations (commit, push, diff) must happen inside the worktree directory
 - Common failure: agent does `git checkout feature-branch` in `/workspace`, another agent commits to the wrong branch
-- **Cleanup is mandatory**: when work is complete (PR created, or task done), run `cd /workspace && git worktree remove /workspace/.claude/worktrees/<name>`. Stale worktrees prevent branch deletion and waste disk. If the agent crashes, the orchestrator or next agent should clean up orphaned worktrees with `git worktree prune`.
+- **Cleanup is mandatory**: when work is complete (PR created, or task done), remove the worktree. Stale worktrees prevent branch deletion and waste disk. The merge worktree is cleaned up automatically by `create-pr`; agent worktrees are cleaned up by `do_merge()`. For manual cleanup: `cd /workspace` (standalone), then `git worktree remove <path>` (standalone), then `git worktree prune`.
 
 ## WATCH Mode
 `WATCH=1` runs agents in tmux windows with visible output.
@@ -69,3 +70,5 @@ Every group prompt should include in its Error Handling section:
 - **`script -q -c` is fragile**: Prefer `tee -a` for simultaneous terminal + file capture.
 - **Validation log parsing**: Must exclude the `COMMAND=` header line to avoid false positive failure detection from prompt template strings.
 - **Container dependencies**: tmux must be in the Dockerfile's `apt-get install` line. If missing, WATCH mode is completely broken with no useful error.
+- **`CLAUDECODE` env var blocks nested sessions**: When `launch-phase.sh` is run from a supervisor agent (Claude Code), child `claude` processes refuse to start. Fixed by `unset CLAUDECODE` at the top of `launch-phase.sh`.
+- **Merge worktree isolation**: Merge/validate/PR steps must never `git checkout` in `/workspace`. The `do_merge()`, `validate()`, and `create_pr()` functions operate in a dedicated merge worktree (`MERGE_WORKTREE`). This prevents dirty state, Cargo.lock conflicts, and pre-commit hook issues.

--- a/docs/multi-agent-guide.md
+++ b/docs/multi-agent-guide.md
@@ -100,6 +100,10 @@ The supervisor replaces the `all` command with intelligent step-by-step orchestr
 - Drives validation and PR creation
 - Handles the code review loop: reads review comments, fixes issues, re-triggers review
 
+**Worktree isolation:** All merge, validation, and PR operations happen in a dedicated merge
+worktree (`/workspace/.claude/worktrees/<phase>-merge`). Agent work happens in per-group
+worktrees. `/workspace` stays on `main` throughout the entire pipeline.
+
 **When to use supervisor vs `all`:**
 - Use `all` for simple phases where automated retry logic is sufficient
 - Use supervisor for complex phases, risky merges, or when you want intelligent failure handling

--- a/docs/prompts/supervisor.md
+++ b/docs/prompts/supervisor.md
@@ -64,7 +64,7 @@ This blocks until all parallel agents in the stage finish. The command handles w
 ./scripts/launch-phase.sh <config> merge <N>
 ```
 
-This merges succeeded branches to the implementation branch, runs build verification (WASM + tsc + vitest + cargo test), and auto-launches fix agents if verification fails.
+This merges succeeded branches to the implementation branch in a dedicated merge worktree (`/workspace/.claude/worktrees/<phase>-merge`). It runs build verification (WASM + tsc + vitest + cargo test) and auto-launches fix agents if verification fails. The merge worktree persists across stages and is cleaned up after PR creation. `/workspace` stays on `main` at all times.
 
 **Check merge results:**
 - Exit code 0 = clean merge + verification passed
@@ -141,8 +141,10 @@ Once the code review finds no issues:
    gh pr merge <number> --squash --delete-branch
    ```
 
-3. Clean up all remaining worktrees (**each command must be a separate Bash call** — never chain `cd` with `&&`):
+3. Clean up any remaining worktrees (**each command must be a separate Bash call** — never chain `cd` with `&&`):
    ```bash
+   # The merge worktree is cleaned up automatically by create-pr.
+   # Only clean up manually if worktrees remain (e.g., from review-fix work):
    # Bash call 1:
    cd /workspace
    # Bash call 2:
@@ -191,7 +193,7 @@ MODEL=sonnet ./scripts/launch-phase.sh <config> stage 1
 - DO stop and report if a step fails unexpectedly (launch-phase.sh crashes, git state corruption, etc.).
 - Do NOT modify source code directly during stages. All code changes happen through the agents spawned by launch-phase.sh. Exception: you MAY fix issues found by code review directly in Step 4.
 - Do NOT push to main directly. Use `gh pr merge --squash --delete-branch` after the review loop is clean.
-- Do NOT run `git checkout` or `git switch` in `/workspace`. It must stay on `main`.
+- Do NOT run `git checkout` or `git switch` in `/workspace`. It must stay on `main`. All merge/validate/PR operations happen inside a dedicated merge worktree automatically.
 - NEVER chain `cd` with `&&` or `;`. Always run `cd` as a standalone Bash call. If a chained command fails, the `cd` does not persist and all subsequent calls run in the wrong (potentially deleted) directory.
 - Follow all rules in `/workspace/CLAUDE.md`, especially the arithmetic rule (use tools for any calculations).
 

--- a/scripts/lib/config.sh
+++ b/scripts/lib/config.sh
@@ -80,6 +80,7 @@ load_config() {
   # Derived values
   LOG_DIR="${WORKSPACE}/logs/${PHASE}"
   TMUX_SESSION="${PHASE}-agents"
+  MERGE_WORKTREE="${WORKTREE_BASE}/${PHASE}-merge"
 
   mkdir -p "$LOG_DIR"
 

--- a/scripts/lib/merge.sh
+++ b/scripts/lib/merge.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 # scripts/lib/merge.sh — Branch merging with conflict resolution and post-merge verification
+#
+# All merge operations happen inside the merge worktree (MERGE_WORKTREE),
+# never in /workspace. This keeps /workspace on main at all times.
 
 # Ensure the implementation branch exists (created from main).
 setup_merge_target() {
@@ -11,11 +14,12 @@ setup_merge_target() {
 }
 
 # Launch a Claude agent to resolve merge conflicts.
+# All operations run inside the merge worktree.
 resolve_merge_conflicts() {
   local branch="$1"
   local msg="$2"
   local conflicts
-  conflicts=$(cd "$WORKSPACE" && git diff --name-only --diff-filter=U)
+  conflicts=$(cd "$MERGE_WORKTREE" && git diff --name-only --diff-filter=U)
 
   if [[ -z "$conflicts" ]]; then
     warn "resolve_merge_conflicts called but no conflicted files found"
@@ -29,12 +33,12 @@ resolve_merge_conflicts() {
   while IFS= read -r f; do
     conflict_diffs+="
 === $f ===
-$(head -200 "$f")
+$(cd "$MERGE_WORKTREE" && head -200 "$f")
 "
   done <<< "$conflicts"
 
   local branch_summary
-  branch_summary=$(git log --oneline "${MERGE_TARGET}".."$branch" 2>/dev/null | head -10 || echo "(no commits)")
+  branch_summary=$(cd "$MERGE_WORKTREE" && git log --oneline "${MERGE_TARGET}".."$branch" 2>/dev/null | head -10 || echo "(no commits)")
 
   local fix_prompt="You are resolving git merge conflicts in the Ganttlet project.
 The branch '${branch}' is being merged into ${MERGE_TARGET}. The following files have conflicts:
@@ -57,8 +61,6 @@ Instructions:
 
 Do NOT enter plan mode. Do NOT ask for confirmation. Fix the conflicts and commit."
 
-  cd "$WORKSPACE"
-
   if [[ "$WATCH" == "1" ]]; then
     local fix_prompt_file="${LOG_DIR}/merge-fix-${branch//\//-}.md"
     echo "$fix_prompt" > "$fix_prompt_file"
@@ -68,7 +70,7 @@ Do NOT enter plan mode. Do NOT ask for confirmation. Fix the conflicts and commi
     local wrapper="${LOG_DIR}/merge-fix-run.sh"
     cat > "$wrapper" <<WRAPPER
 #!/usr/bin/env bash
-cd "$WORKSPACE"
+cd "${MERGE_WORKTREE}"
 claude --dangerously-skip-permissions --max-turns "${MAX_TURNS:-$DEFAULT_MAX_TURNS}" --max-budget-usd "${MAX_BUDGET:-$DEFAULT_MAX_BUDGET}" -p "\$(cat '$fix_prompt_file')"
 echo \$? > "$exitcode_file"
 WRAPPER
@@ -88,15 +90,21 @@ WRAPPER
     tmux kill-session -t "${TMUX_SESSION}-merge-fix" 2>/dev/null || true
     return "$rc"
   else
-    echo "$fix_prompt" | claude --dangerously-skip-permissions --max-turns "${MAX_TURNS:-$DEFAULT_MAX_TURNS}" --max-budget-usd "${MAX_BUDGET:-$DEFAULT_MAX_BUDGET}" -p - >> "${LOG_DIR}/merge-fix.log" 2>&1
+    (
+      cd "$MERGE_WORKTREE"
+      echo "$fix_prompt" | claude --dangerously-skip-permissions --max-turns "${MAX_TURNS:-$DEFAULT_MAX_TURNS}" --max-budget-usd "${MAX_BUDGET:-$DEFAULT_MAX_BUDGET}" -p - >> "${LOG_DIR}/merge-fix.log" 2>&1
+    )
     return $?
   fi
 }
 
 # Merge a single branch with conflict resolution retries.
+# Runs inside the merge worktree.
 merge_branch_with_retries() {
   local branch="$1"
   local msg="$2"
+
+  cd "$MERGE_WORKTREE"
 
   if ! git rev-parse --verify "$branch" >/dev/null 2>&1; then
     err "Branch '${branch}' does not exist — agents may not have run. Skipping."
@@ -136,6 +144,7 @@ merge_branch_with_retries() {
 }
 
 # Launch a fix agent that keeps running until tsc + vitest + cargo test all pass.
+# Runs inside the merge worktree.
 run_merge_fix_agent() {
   local merge_label="$1"
   local max_fix_attempts="${MERGE_FIX_RETRIES:-3}"
@@ -160,19 +169,21 @@ Do NOT modify files unnecessarily. Only fix actual errors. Read the error output
     log "Merge-fix attempt ${attempt}/${max_fix_attempts}"
     local logfile="${LOG_DIR}/merge-fix-${merge_label// /-}-attempt${attempt}.log"
 
-    cd "$WORKSPACE"
     local max_turns="${MAX_TURNS:-$DEFAULT_MAX_TURNS}"
     local max_budget="${MAX_BUDGET:-$DEFAULT_MAX_BUDGET}"
 
     set +e
-    echo "$fix_prompt" | claude --dangerously-skip-permissions --max-turns "$max_turns" --max-budget-usd "$max_budget" -p - > "$logfile" 2>&1
+    (
+      cd "$MERGE_WORKTREE"
+      echo "$fix_prompt" | claude --dangerously-skip-permissions --max-turns "$max_turns" --max-budget-usd "$max_budget" -p - > "$logfile" 2>&1
+    )
     local exit_code=$?
     set -e
 
     local all_ok=true
-    npx tsc --noEmit >/dev/null 2>&1 || all_ok=false
-    npm run test >/dev/null 2>&1 || all_ok=false
-    (source "$HOME/.cargo/env" 2>/dev/null; cd crates/scheduler && cargo test >/dev/null 2>&1) || all_ok=false
+    (cd "$MERGE_WORKTREE" && npx tsc --noEmit >/dev/null 2>&1) || all_ok=false
+    (cd "$MERGE_WORKTREE" && npm run test >/dev/null 2>&1) || all_ok=false
+    (cd "$MERGE_WORKTREE" && source "$HOME/.cargo/env" 2>/dev/null; cd "$MERGE_WORKTREE/crates/scheduler" && cargo test >/dev/null 2>&1) || all_ok=false
 
     if $all_ok; then
       ok "Merge-fix agent resolved all issues on attempt ${attempt}"
@@ -190,6 +201,7 @@ Do NOT modify files unnecessarily. Only fix actual errors. Read the error output
 }
 
 # Run merge stage for a given stage index: merge all branches, verify, fix if needed.
+# All operations run in the merge worktree — /workspace stays on main.
 # Usage: do_merge "Merge 1" groups_array branches_array messages_array
 do_merge() {
   local merge_label="$1"
@@ -199,15 +211,10 @@ do_merge() {
 
   log "=== ${merge_label}: Combining parallel branches into ${MERGE_TARGET} ==="
 
-  cd "$WORKSPACE"
-  setup_merge_target
+  # Create/reuse merge worktree (persists across stages)
+  setup_merge_worktree
 
-  local current_branch
-  current_branch=$(git branch --show-current)
-  if [[ "$current_branch" != "$MERGE_TARGET" ]]; then
-    log "Switching to ${MERGE_TARGET}..."
-    git checkout "$MERGE_TARGET"
-  fi
+  cd "$MERGE_WORKTREE"
 
   # Check which groups succeeded (if stage result files exist)
   local succeeded=""
@@ -231,14 +238,15 @@ do_merge() {
   done
 
   # Rebuild WASM (Rust source may have changed)
+  cd "$MERGE_WORKTREE"
   log "Rebuilding WASM..."
   source "$HOME/.cargo/env" 2>/dev/null || true
   npm run build:wasm || warn "WASM build failed (may not have Rust changes)"
 
   # Commit Cargo.lock if it was modified by the build (new deps from merged Cargo.toml)
   if [[ -n "$(git diff --name-only -- crates/scheduler/Cargo.lock 2>/dev/null)" ]]; then
-    WORKTREE_EXEMPT=1 git add crates/scheduler/Cargo.lock
-    WORKTREE_EXEMPT=1 git commit -m "chore: update Cargo.lock after ${merge_label}"
+    git add crates/scheduler/Cargo.lock
+    git commit -m "chore: update Cargo.lock after ${merge_label}"
   fi
 
   # Verify build
@@ -272,12 +280,11 @@ do_merge() {
     fi
   fi
 
-  # Cleanup worktrees
+  # Cleanup agent worktrees (not the merge worktree — it persists for validate/PR)
   cleanup_worktrees "$2" "$3"
 
-  # Return to main so /workspace stays clean for the next stage's preflight check.
+  # Return to /workspace (stays on main)
   cd "$WORKSPACE"
-  git checkout main
 
   ok "=== ${merge_label} complete ==="
 }

--- a/scripts/lib/pr.sh
+++ b/scripts/lib/pr.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 # scripts/lib/pr.sh — PR creation and code review trigger
+#
+# Operates from the merge worktree (MERGE_WORKTREE) for git push,
+# but gh commands work from anywhere.
 
 # Create a PR from the implementation branch to main.
 # Uses PR metadata from the YAML config if available, otherwise generates from commit log.
 create_pr() {
-  cd "$WORKSPACE"
+  # Ensure merge worktree exists (may be called standalone via `create-pr` command)
+  setup_merge_worktree
 
-  local current_branch
-  current_branch=$(git branch --show-current)
-  if [[ "$current_branch" != "$MERGE_TARGET" ]]; then
-    git checkout "$MERGE_TARGET"
-  fi
+  cd "$MERGE_WORKTREE"
 
   log "Pushing ${MERGE_TARGET} to origin..."
   git push -u origin "$MERGE_TARGET"
@@ -93,6 +93,10 @@ ${PR_TEST_PLAN}"
   else
     warn "Could not extract PR number from: ${pr_url} — skipping code review"
   fi
+
+  # Clean up the merge worktree — no longer needed after push + PR creation
+  cd "$WORKSPACE"
+  cleanup_merge_worktree
 
   ok "=== PR created and code review triggered ==="
 }

--- a/scripts/lib/validate.sh
+++ b/scripts/lib/validate.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 # scripts/lib/validate.sh — Validation agent runner (pipe mode)
+#
+# Runs inside the merge worktree (MERGE_WORKTREE), not /workspace.
 
 # Run the validation agent with retry loop.
 validate() {
@@ -15,6 +17,9 @@ validate() {
     warn "No validation prompt found at $prompt_file — skipping."
     return 0
   fi
+
+  # Ensure merge worktree exists (may be called standalone via `validate` command)
+  setup_merge_worktree
 
   log "=== Running validation agent (up to ${max_attempts} attempts) ==="
 
@@ -45,18 +50,13 @@ ${prompt}"
     fi
 
     log "Validation attempt ${attempt}/${max_attempts} (log: ${logfile})"
-    cd "$WORKSPACE"
-
-    local current_branch
-    current_branch=$(git branch --show-current)
-    if [[ "$current_branch" != "$MERGE_TARGET" ]]; then
-      log "Switching to ${MERGE_TARGET} for validation..."
-      git checkout "$MERGE_TARGET"
-    fi
 
     local max_turns="${MAX_TURNS:-$DEFAULT_MAX_TURNS}"
     local max_budget="${MAX_BUDGET:-$DEFAULT_MAX_BUDGET}"
-    echo "$prompt" | claude --dangerously-skip-permissions --max-turns "$max_turns" --max-budget-usd "$max_budget" -p - > "$logfile" 2>&1
+    (
+      cd "$MERGE_WORKTREE"
+      echo "$prompt" | claude --dangerously-skip-permissions --max-turns "$max_turns" --max-budget-usd "$max_budget" -p - > "$logfile" 2>&1
+    )
     local exit_code=$?
 
     if [[ $exit_code -ne 0 ]]; then

--- a/scripts/lib/watch.sh
+++ b/scripts/lib/watch.sh
@@ -353,7 +353,7 @@ ${prev_errors}"
     cat > "$wrapper" <<VALIDATE_WRAPPER
 #!/usr/bin/env bash
 set -uo pipefail
-cd "${WORKSPACE}"
+cd "${MERGE_WORKTREE}"
 
 claude --dangerously-skip-permissions -p "echo ok" >/dev/null 2>&1 || true
 

--- a/scripts/lib/worktree.sh
+++ b/scripts/lib/worktree.sh
@@ -50,6 +50,36 @@ SEED
   echo "$worktree"
 }
 
+# Setup the merge worktree for the implementation branch.
+# This worktree persists across stages (merge → validate → create-pr).
+setup_merge_worktree() {
+  if [[ -d "$MERGE_WORKTREE" ]]; then
+    log "Merge worktree already exists: ${MERGE_WORKTREE}"
+    return 0
+  fi
+
+  setup_merge_target  # ensure the implementation branch exists
+
+  log "Creating merge worktree: ${MERGE_WORKTREE} (branch: ${MERGE_TARGET})"
+  cd "$WORKSPACE"
+  git worktree add "$MERGE_WORKTREE" "$MERGE_TARGET" >/dev/null 2>&1 || \
+    { err "Failed to create merge worktree"; return 1; }
+
+  # Install dependencies so tsc/vitest can run in the worktree
+  (cd "$MERGE_WORKTREE" && npm install --silent >/dev/null 2>&1) || true
+}
+
+# Remove the merge worktree. Called after PR creation or on pipeline cleanup.
+cleanup_merge_worktree() {
+  if [[ -d "$MERGE_WORKTREE" ]]; then
+    log "Removing merge worktree: ${MERGE_WORKTREE}"
+    cd "$WORKSPACE"
+    git worktree remove "$MERGE_WORKTREE" --force 2>/dev/null || \
+      warn "Could not remove merge worktree: ${MERGE_WORKTREE}"
+    git worktree prune 2>/dev/null || true
+  fi
+}
+
 # Remove worktrees and delete branches for a list of groups.
 # Usage: cleanup_worktrees groups_array branches_array
 cleanup_worktrees() {


### PR DESCRIPTION
## Summary

All merge, validation, and PR operations now run in a dedicated merge worktree instead of checking out branches in `/workspace`. This fixes multiple issues discovered during Phase 15 orchestration:

- `/workspace` never leaves `main` during any pipeline step
- No more dirty Cargo.lock or `WORKTREE_EXEMPT` hacks after merge
- Preflight checks no longer fail due to wrong branch state
- Pre-commit hook no longer blocks commits on feature branches in `/workspace`

The merge worktree (`/workspace/.claude/worktrees/<phase>-merge`) is long-lived — it persists across stages for the merge → validate → create-pr flow and is cleaned up automatically after PR creation.

## Changes

- `worktree.sh`: new `setup_merge_worktree()` and `cleanup_merge_worktree()` functions
- `merge.sh`: rewrite `do_merge()`, `merge_branch_with_retries()`, `resolve_merge_conflicts()`, `run_merge_fix_agent()` to operate in `MERGE_WORKTREE`
- `validate.sh`: run validation agent in `MERGE_WORKTREE`
- `pr.sh`: push from `MERGE_WORKTREE`, cleanup after PR creation
- `config.sh`: add `MERGE_WORKTREE` as derived global alongside `LOG_DIR`
- `watch.sh`: update validate wrapper `cd` target
- `supervisor.md`: document merge worktree behavior
- `multi-agent-guide.md`: add worktree isolation note
- `SKILL.md`: update worktree docs, add `CLAUDECODE` and merge isolation lessons

## Test plan

- [ ] `bash -n scripts/lib/*.sh` — all scripts parse cleanly
- [ ] `./scripts/launch-phase.sh <config> status` works
- [ ] Run a phase with `stage N` → `merge N` and verify `/workspace` stays on `main`
- [ ] Verify merge worktree is created at `/workspace/.claude/worktrees/<phase>-merge`
- [ ] Verify merge worktree is cleaned up after `create-pr`

🤖 Generated with [Claude Code](https://claude.com/claude-code)