### PR TITLE
feat: per-branch merge verification, stage timeouts, and cleanup command

### DIFF
--- a/.claude/skills/multi-agent-orchestration/SKILL.md
+++ b/.claude/skills/multi-agent-orchestration/SKILL.md
@@ -8,8 +8,11 @@ description: "Use when modifying launch-phase.sh, creating phase prompts, debugg
 ## launch-phase.sh Architecture
 - **Stages**: Sequential groups of parallel agents (stage1 → merge1 → stage2 → merge2 → ...)
 - **Merge gating**: Each stage's branches must merge cleanly before the next stage starts
+- **Per-branch verification**: After each branch merge, tsc/vitest/cargo test run in parallel
+- **Stage timeouts**: `MAX_STAGE_DURATION` (default 1800s) kills stalled agents
 - **Retry-on-crash**: Agents that crash are restarted automatically
 - **Validation**: Post-merge validation agent runs fix-and-retry cycles
+- **Cleanup command**: `./scripts/launch-phase.sh <config> cleanup` removes all phase worktrees/branches
 
 See `docs/multi-agent-guide.md` for full command reference and usage examples.
 
@@ -72,3 +75,6 @@ Every group prompt should include in its Error Handling section:
 - **Container dependencies**: tmux must be in the Dockerfile's `apt-get install` line. If missing, WATCH mode is completely broken with no useful error.
 - **`CLAUDECODE` env var blocks nested sessions**: When `launch-phase.sh` is run from a supervisor agent (Claude Code), child `claude` processes refuse to start. Fixed by `unset CLAUDECODE` at the top of `launch-phase.sh`.
 - **Merge worktree isolation**: Merge/validate/PR steps must never `git checkout` in `/workspace`. The `do_merge()`, `validate()`, and `create_pr()` functions operate in a dedicated merge worktree (`MERGE_WORKTREE`). This prevents dirty state, Cargo.lock conflicts, and pre-commit hook issues.
+- **Per-branch verification**: Verifying after ALL branches are merged makes failures harder to diagnose (compound errors). `do_merge()` now runs `run_parallel_verification()` after each branch, catching breakage before the next branch is merged on top.
+- **Parallel verification is faster**: Running tsc, vitest, and cargo test with `&` + `wait` instead of sequentially saves significant time during merge verification.
+- **Code review rounds should be capped**: Without a cap, the review-fix-review loop can cycle indefinitely. The supervisor prompt caps at 3 rounds; beyond that, add `needs-human-review` label.

--- a/docs/multi-agent-guide.md
+++ b/docs/multi-agent-guide.md
@@ -25,6 +25,7 @@ WATCH=1 ./scripts/launch-phase.sh docs/prompts/phase15/launch-config.yaml all
 ./scripts/launch-phase.sh <config> validate   # run validation agent (fix-and-retry)
 ./scripts/launch-phase.sh <config> create-pr  # create PR + trigger code review
 ./scripts/launch-phase.sh <config> resume stage:2  # resume pipeline from a specific step
+./scripts/launch-phase.sh <config> cleanup    # remove all phase worktrees and branches
 ./scripts/launch-phase.sh <config> status     # show worktree/branch status
 ```
 
@@ -34,8 +35,11 @@ The config file defines phase name, stages, groups, branches, merge messages, an
 ## Preflight Checks
 
 Before launching any parallel stage, `launch-phase.sh` runs `preflight_check()` which verifies:
+- **claude CLI available** — checks `command -v claude` and logs version
+- **tmux available** (if `WATCH=1`) — fails fast instead of silently breaking
 - **Clean git state** — uncommitted changes cause an immediate abort
 - **Prompt files exist** — all groups in the stage must have a matching `.md` file
+- **Merge target viable** — verifies the implementation branch exists or can be created from main
 - **WASM builds** — runs `npm run build:wasm` to catch broken builds before agents start
 
 Preflight runs automatically at the start of every `run_parallel_stage()` call.
@@ -47,6 +51,39 @@ If some agents in a parallel stage succeed and others fail, the pipeline continu
 - Results are written to `${LOG_DIR}/stage-succeeded.txt` and `stage-failed.txt`
 - The merge stage reads these files and **skips merging branches from failed groups**
 - The pipeline only aborts if ALL groups in a stage fail; partial success continues
+
+## Per-Branch Merge Verification
+
+The merge step verifies the build **after each branch merge**, not just after all branches are merged.
+This catches breakage early — before merging more branches on top of broken code.
+
+After each successful branch merge, the pipeline:
+1. Rebuilds WASM (Rust source may have changed)
+2. Commits `Cargo.lock` if modified
+3. Runs tsc, vitest, and cargo test **in parallel** (with `&` + `wait`)
+4. If verification fails, launches a merge-fix agent to resolve issues
+
+This means a merge with 3 branches runs verification 3 times, but each run is faster because
+tsc/vitest/cargo test execute concurrently. The tradeoff is worth it: catching a type error after
+the first merge is far cheaper than debugging a compound failure after merging all 3 branches.
+
+## Stage Timeouts
+
+Stages have a configurable timeout (`MAX_STAGE_DURATION`, default 1800 seconds / 30 minutes).
+If agents in a stage exceed the timeout, they are killed (SIGTERM → SIGKILL after 5 seconds)
+and treated as failures. Set `MAX_STAGE_DURATION=0` to disable the timeout.
+
+## Cleanup Command
+
+Remove all worktrees and branches for a phase:
+```bash
+./scripts/launch-phase.sh <config> cleanup
+```
+
+This is useful after a failed pipeline run or when you want to start fresh. It removes:
+- The merge worktree (`<phase>-merge`)
+- All agent worktrees (`<phase>-<group>`)
+- All branches matching the phase name
 
 ## Stall Detection
 
@@ -84,6 +121,7 @@ executes from the given step through the end. Also supports space-separated synt
 | `DEFAULT_MAX_TURNS` | `80` | Max conversation turns per agent |
 | `DEFAULT_MAX_BUDGET` | `10.00` | Max USD budget per agent |
 | `STALL_TIMEOUT` | `30` | Minutes of inactivity before stall warning |
+| `MAX_STAGE_DURATION` | `1800` | Max seconds per stage before killing agents (0=disabled) |
 | `MODEL` | (unset) | Override Claude model (`opus`, `sonnet`, `haiku`) |
 
 ## Supervisor Mode

--- a/docs/prompts/supervisor.md
+++ b/docs/prompts/supervisor.md
@@ -19,9 +19,10 @@ All commands require the config file as the first argument:
 ```bash
 ./scripts/launch-phase.sh <config> status       # Current state overview
 ./scripts/launch-phase.sh <config> stage <N>     # Run stage N parallel groups
-./scripts/launch-phase.sh <config> merge <N>     # Merge stage N branches
+./scripts/launch-phase.sh <config> merge <N>     # Merge stage N branches (verifies after each)
 ./scripts/launch-phase.sh <config> validate      # Run validation agent
 ./scripts/launch-phase.sh <config> create-pr     # Create PR + trigger code review
+./scripts/launch-phase.sh <config> cleanup       # Remove all phase worktrees and branches
 ```
 
 ## Execution Protocol
@@ -64,7 +65,7 @@ This blocks until all parallel agents in the stage finish. The command handles w
 ./scripts/launch-phase.sh <config> merge <N>
 ```
 
-This merges succeeded branches to the implementation branch in a dedicated merge worktree (`/workspace/.claude/worktrees/<phase>-merge`). It runs build verification (WASM + tsc + vitest + cargo test) and auto-launches fix agents if verification fails. The merge worktree persists across stages and is cleaned up after PR creation. `/workspace` stays on `main` at all times.
+This merges succeeded branches to the implementation branch in a dedicated merge worktree (`/workspace/.claude/worktrees/<phase>-merge`). After each branch merge, it runs build verification (WASM + tsc + vitest + cargo test in parallel) and auto-launches fix agents if verification fails. This catches breakage early — before merging more branches on top. The merge worktree persists across stages and is cleaned up after PR creation. `/workspace` stays on `main` at all times.
 
 **Check merge results:**
 - Exit code 0 = clean merge + verification passed
@@ -108,7 +109,8 @@ This pushes the implementation branch and creates a PR via `gh pr create`. It al
 
 ### Step 4: Code Review Loop
 
-After the PR is created, manage the code review loop until the PR is clean:
+After the PR is created, manage the code review loop until the PR is clean.
+**Maximum review rounds: 3.** If issues persist after 3 rounds, add a `needs-human-review` label and proceed to Step 5 with a note that the review is incomplete.
 
 1. Wait briefly (30-60 seconds) for the background code review to complete
 2. Check for review comments on the PR:
@@ -122,9 +124,9 @@ After the PR is created, manage the code review loop until the PR is clean:
      git worktree add /workspace/.claude/worktrees/<phase>-review-fix <merge_target>
      ```
    - Make the fixes, commit, and push
-   - Re-trigger code review using the `/code-review` skill with the PR number
+   - When re-triggering code review, include the previous review comment body in your review prompt so the reviewer can skip issues that were already fixed. This prevents re-flagging resolved issues.
    - Wait for the new review, then check comments again
-   - **Repeat this loop until the review returns "No issues found"**
+   - **Repeat this loop until the review returns "No issues found" or you hit the 3-round cap**
 4. If the review found no issues: proceed to Step 5
 5. Clean up any worktrees created during the review loop
 
@@ -155,10 +157,12 @@ Once the code review finds no issues:
    - If `MERGED` → proceed to cleanup
    - If not merged → do NOT delete worktrees. Diagnose the failure, fix, and retry the merge. The worktree is your only working copy of the branch.
 
-4. Clean up any remaining worktrees (**each command must be a separate Bash call** — never chain `cd` with `&&`):
+4. Clean up all phase worktrees and branches:
    ```bash
-   # The merge worktree is cleaned up automatically by create-pr.
-   # Only clean up manually if worktrees remain (e.g., from review-fix work):
+   ./scripts/launch-phase.sh <config> cleanup
+   ```
+   This removes all worktrees matching the phase, prunes stale references, and deletes phase branches. If cleanup fails for specific worktrees, clean up manually (**each command must be a separate Bash call** — never chain `cd` with `&&`):
+   ```bash
    # Bash call 1:
    cd /workspace
    # Bash call 2:
@@ -197,6 +201,7 @@ You can set env vars per-command to customize behavior:
 ```bash
 MAX_RETRIES=5 ./scripts/launch-phase.sh <config> stage 1
 VALIDATE_MAX_ATTEMPTS=5 ./scripts/launch-phase.sh <config> validate
+MAX_STAGE_DURATION=3600 ./scripts/launch-phase.sh <config> stage 1   # 1 hour timeout
 MODEL=sonnet ./scripts/launch-phase.sh <config> stage 1
 ```
 

--- a/scripts/launch-phase.sh
+++ b/scripts/launch-phase.sh
@@ -23,6 +23,7 @@
 #   RETRY_DELAY=5       — seconds between retries
 #   VALIDATE_MAX_ATTEMPTS=3 — max fix-and-retry cycles for validation
 #   MERGE_FIX_RETRIES=3 — retries for merge conflict resolution
+#   MAX_STAGE_DURATION=1800 — max seconds per stage before killing agents
 #   MERGE_TARGET        — override implementation branch (default: from config)
 #   WORKTREE_BASE       — worktree root (default: /workspace/.claude/worktrees)
 
@@ -44,6 +45,7 @@ WORKTREE_BASE="${WORKTREE_BASE:-/workspace/.claude/worktrees}"
 WORKSPACE="/workspace"
 WATCH="${WATCH:-0}"
 VALIDATE_MAX_ATTEMPTS="${VALIDATE_MAX_ATTEMPTS:-3}"
+MAX_STAGE_DURATION="${MAX_STAGE_DURATION:-1800}"  # 30 minutes default
 
 # Preserve user's explicit MERGE_TARGET (empty if unset)
 _USER_MERGE_TARGET="${MERGE_TARGET:-}"
@@ -78,6 +80,7 @@ Commands:
   validate          Run validation agent (checks all tests, fixes issues, reports)
   create-pr         Create PR from implementation branch to main + trigger code review
   resume <step>     Resume pipeline from a step (e.g., "stage:2", "merge:1", "validate")
+  cleanup           Remove all worktrees and prune branches for this phase
   status            Show current worktree and branch status
   logs [group]      Tail agent logs (optionally for a specific group)
 
@@ -87,6 +90,7 @@ Environment variables:
   RETRY_DELAY=5              Seconds between retries
   VALIDATE_MAX_ATTEMPTS=3    Max fix-and-retry cycles for validation
   MERGE_FIX_RETRIES=3        Retries for merge conflict resolution
+  MAX_STAGE_DURATION=1800    Max seconds per stage before killing agents (0=disabled)
   MERGE_TARGET               Override implementation branch
   MODEL                      Override Claude model (opus, sonnet, haiku)
 USAGE
@@ -264,6 +268,55 @@ show_status() {
   ls -lh "$LOG_DIR" 2>/dev/null || echo "  (no logs yet)"
 }
 
+# Remove all worktrees and branches for this phase.
+cleanup_phase() {
+  log "=== Cleaning up phase: ${PHASE} ==="
+  cd "$WORKSPACE"
+
+  # Remove merge worktree
+  cleanup_merge_worktree
+
+  # Find and remove all phase worktrees
+  local worktree_pattern="${WORKTREE_BASE}/${PHASE}-"
+  local removed=0
+  for wt in "${worktree_pattern}"*; do
+    if [[ -d "$wt" ]]; then
+      log "Removing worktree: ${wt}"
+      git worktree remove "$wt" --force 2>/dev/null || \
+        warn "Could not remove worktree: ${wt}"
+      removed=$((removed + 1))
+    fi
+  done
+
+  # Prune any stale worktree references
+  git worktree prune 2>/dev/null || true
+
+  # Remove phase branches (implementation branch + group branches)
+  local phase_branches
+  phase_branches=$(git branch --list "*${PHASE}*" 2>/dev/null || echo "")
+  if [[ -n "$phase_branches" ]]; then
+    while IFS= read -r branch; do
+      branch=$(echo "$branch" | sed 's/^[* ]*//')
+      if [[ -n "$branch" && "$branch" != "main" ]]; then
+        log "Deleting branch: ${branch}"
+        git branch -d "$branch" 2>/dev/null || \
+          warn "Could not delete branch: ${branch} (may need -D)"
+      fi
+    done <<< "$phase_branches"
+  fi
+
+  log "Verifying cleanup..."
+  echo ""
+  echo "Remaining worktrees:"
+  git worktree list
+  echo ""
+  echo "Remaining branches matching ${PHASE}:"
+  git branch --list "*${PHASE}*" 2>/dev/null || echo "  (none)"
+  echo ""
+
+  ok "=== Phase ${PHASE} cleanup complete (${removed} worktrees removed) ==="
+}
+
 show_logs() {
   local group="${1:-}"
   if [[ -n "$group" ]]; then
@@ -314,6 +367,9 @@ case "$COMMAND" in
       resume_step="${1}:${2}"
     fi
     run_pipeline "$resume_step"
+    ;;
+  cleanup)
+    cleanup_phase
     ;;
   status)
     show_status

--- a/scripts/lib/merge.sh
+++ b/scripts/lib/merge.sh
@@ -143,6 +143,49 @@ merge_branch_with_retries() {
   return 1
 }
 
+# Run tsc + vitest + cargo test in parallel. Returns 0 if all pass.
+# Runs inside the merge worktree.
+run_parallel_verification() {
+  local label="${1:-verification}"
+
+  log "Running parallel verification (tsc + vitest + cargo test) for ${label}..."
+
+  local tsc_log="${LOG_DIR}/verify-tsc.log"
+  local vitest_log="${LOG_DIR}/verify-vitest.log"
+  local cargo_log="${LOG_DIR}/verify-cargo.log"
+
+  (cd "$MERGE_WORKTREE" && npx tsc --noEmit > "$tsc_log" 2>&1) &
+  local tsc_pid=$!
+
+  (cd "$MERGE_WORKTREE" && npm run test > "$vitest_log" 2>&1) &
+  local vitest_pid=$!
+
+  (cd "$MERGE_WORKTREE" && source "$HOME/.cargo/env" 2>/dev/null; cd "$MERGE_WORKTREE/crates/scheduler" && cargo test > "$cargo_log" 2>&1) &
+  local cargo_pid=$!
+
+  local tsc_ok=true vitest_ok=true cargo_ok=true
+  set +e
+  wait $tsc_pid || tsc_ok=false
+  wait $vitest_pid || vitest_ok=false
+  wait $cargo_pid || cargo_ok=false
+  set -e
+
+  if ! $tsc_ok; then
+    err "TypeScript check failed (${label})"
+    tail -20 "$tsc_log" 2>/dev/null || true
+  fi
+  if ! $vitest_ok; then
+    err "Unit tests failed (${label})"
+    tail -20 "$vitest_log" 2>/dev/null || true
+  fi
+  if ! $cargo_ok; then
+    err "Rust tests failed (${label})"
+    tail -20 "$cargo_log" 2>/dev/null || true
+  fi
+
+  $tsc_ok && $vitest_ok && $cargo_ok
+}
+
 # Launch a fix agent that keeps running until tsc + vitest + cargo test all pass.
 # Runs inside the merge worktree.
 run_merge_fix_agent() {
@@ -180,12 +223,7 @@ Do NOT modify files unnecessarily. Only fix actual errors. Read the error output
     local exit_code=$?
     set -e
 
-    local all_ok=true
-    (cd "$MERGE_WORKTREE" && npx tsc --noEmit >/dev/null 2>&1) || all_ok=false
-    (cd "$MERGE_WORKTREE" && npm run test >/dev/null 2>&1) || all_ok=false
-    (cd "$MERGE_WORKTREE" && source "$HOME/.cargo/env" 2>/dev/null; cd "$MERGE_WORKTREE/crates/scheduler" && cargo test >/dev/null 2>&1) || all_ok=false
-
-    if $all_ok; then
+    if run_parallel_verification "merge-fix attempt ${attempt}"; then
       ok "Merge-fix agent resolved all issues on attempt ${attempt}"
       return 0
     fi
@@ -221,6 +259,7 @@ do_merge() {
   [[ -f "${LOG_DIR}/stage-succeeded.txt" ]] && succeeded=$(cat "${LOG_DIR}/stage-succeeded.txt")
 
   local merge_failures=0
+  local merged_count=0
   for i in "${!dm_branches[@]}"; do
     local group="${dm_groups[$i]}"
     local branch="${dm_branches[$i]}"
@@ -234,50 +273,39 @@ do_merge() {
     if ! merge_branch_with_retries "$branch" "$msg"; then
       err "Failed to merge ${branch} — continuing with remaining branches"
       merge_failures=$((merge_failures + 1))
+      continue
+    fi
+
+    merged_count=$((merged_count + 1))
+
+    # Verify after each branch merge to catch breakage early
+    log "Verifying after merging ${group}..."
+    cd "$MERGE_WORKTREE"
+
+    # Rebuild WASM (Rust source may have changed in this branch)
+    source "$HOME/.cargo/env" 2>/dev/null || true
+    npm run build:wasm 2>/dev/null || warn "WASM build failed after merging ${group}"
+
+    # Commit Cargo.lock if it was modified by the build
+    if [[ -n "$(git diff --name-only -- crates/scheduler/Cargo.lock 2>/dev/null)" ]]; then
+      git add crates/scheduler/Cargo.lock
+      git commit -m "chore: update Cargo.lock after merging ${group}"
+    fi
+
+    if ! run_parallel_verification "after merging ${group}"; then
+      warn "=== Verification failed after merging ${group} — launching fix agent ==="
+      if run_merge_fix_agent "${merge_label} (${group})"; then
+        ok "=== Verification issues after ${group} resolved by fix agent ==="
+      else
+        warn "=== Fix agent could not resolve all issues after ${group} — continuing ==="
+      fi
+    else
+      ok "Verification passed after merging ${group}"
     fi
   done
 
-  # Rebuild WASM (Rust source may have changed)
-  cd "$MERGE_WORKTREE"
-  log "Rebuilding WASM..."
-  source "$HOME/.cargo/env" 2>/dev/null || true
-  npm run build:wasm || warn "WASM build failed (may not have Rust changes)"
-
-  # Commit Cargo.lock if it was modified by the build (new deps from merged Cargo.toml)
-  if [[ -n "$(git diff --name-only -- crates/scheduler/Cargo.lock 2>/dev/null)" ]]; then
-    git add crates/scheduler/Cargo.lock
-    git commit -m "chore: update Cargo.lock after ${merge_label}"
-  fi
-
-  # Verify build
-  log "Verifying merged code..."
-  local verify_ok=true
-
-  log "Running tsc..."
-  if ! npx tsc --noEmit; then
-    err "TypeScript check failed after merge"
-    verify_ok=false
-  fi
-
-  log "Running vitest..."
-  if ! npm run test; then
-    err "Unit tests failed after merge"
-    verify_ok=false
-  fi
-
-  log "Running cargo test..."
-  if ! (source "$HOME/.cargo/env" 2>/dev/null; cd crates/scheduler && cargo test); then
-    err "Rust tests failed after merge"
-    verify_ok=false
-  fi
-
-  if ! $verify_ok; then
-    warn "=== ${merge_label} verification found issues — launching fix agent ==="
-    if run_merge_fix_agent "$merge_label"; then
-      ok "=== ${merge_label} verification issues resolved by fix agent ==="
-    else
-      warn "=== ${merge_label} fix agent could not resolve all issues — validation agent will handle remaining ==="
-    fi
+  if [[ $merged_count -eq 0 ]]; then
+    warn "No branches were merged in ${merge_label}"
   fi
 
   # Cleanup agent worktrees (not the merge worktree — it persists for validate/PR)

--- a/scripts/lib/stage.sh
+++ b/scripts/lib/stage.sh
@@ -5,6 +5,19 @@
 preflight_check() {
   log "=== Preflight check ==="
 
+  # Verify claude CLI is available
+  if ! command -v claude >/dev/null 2>&1; then
+    err "claude CLI not found — install it before launching agents"
+    return 1
+  fi
+  log "claude CLI: $(claude --version 2>/dev/null || echo 'available')"
+
+  # Verify tmux if WATCH mode is enabled
+  if [[ "$WATCH" == "1" ]] && ! command -v tmux >/dev/null 2>&1; then
+    err "WATCH=1 requires tmux but it's not installed"
+    return 1
+  fi
+
   if [[ -n "$(cd "$WORKSPACE" && git status --porcelain)" ]]; then
     err "Dirty git state — commit or stash changes before launching agents"
     return 1
@@ -18,6 +31,18 @@ preflight_check() {
     fi
   done
   $prompts_exist || return 1
+
+  # Verify merge target branch can be created or already exists
+  cd "$WORKSPACE"
+  if ! git rev-parse --verify "$MERGE_TARGET" >/dev/null 2>&1; then
+    if ! git rev-parse --verify main >/dev/null 2>&1; then
+      err "Neither ${MERGE_TARGET} nor main branch exists"
+      return 1
+    fi
+    log "Merge target ${MERGE_TARGET} will be created from main"
+  else
+    log "Merge target ${MERGE_TARGET} already exists"
+  fi
 
   log "Checking WASM build..."
   if ! (cd "$WORKSPACE" && npm run build:wasm > /dev/null 2>&1); then
@@ -80,6 +105,25 @@ run_parallel_stage() {
     return 1
   fi
 
+  # Stage-level timeout watchdog
+  local stage_start
+  stage_start=$(date +%s)
+  local timeout_pid=""
+  if [[ "${MAX_STAGE_DURATION:-0}" -gt 0 ]]; then
+    (
+      sleep "$MAX_STAGE_DURATION"
+      warn "=== ${stage_label}: stage timeout (${MAX_STAGE_DURATION}s) reached — killing agents ==="
+      for pid in "${pids[@]}"; do
+        kill -TERM "$pid" 2>/dev/null || true
+      done
+      sleep 5
+      for pid in "${pids[@]}"; do
+        kill -9 "$pid" 2>/dev/null || true
+      done
+    ) &
+    timeout_pid=$!
+  fi
+
   local succeeded_groups=()
   local failed_groups=()
 
@@ -99,9 +143,19 @@ run_parallel_stage() {
     fi
   done
 
+  # Kill timeout watchdog if it's still running
+  if [[ -n "$timeout_pid" ]]; then
+    kill "$timeout_pid" 2>/dev/null || true
+  fi
+
   for mpid in "${monitor_pids[@]}"; do
     kill "$mpid" 2>/dev/null || true
   done
+
+  local stage_end
+  stage_end=$(date +%s)
+  local stage_elapsed=$(( stage_end - stage_start ))
+  log "${stage_label} completed in ${stage_elapsed}s"
 
   echo "${succeeded_groups[*]}" > "${LOG_DIR}/stage-succeeded.txt"
   echo "${failed_groups[*]}" > "${LOG_DIR}/stage-failed.txt"


### PR DESCRIPTION
## Summary

Implements the Phase 15 orchestration recommendations to make future phases more robust:

- **Per-branch merge verification**: `do_merge()` now runs tsc + vitest + cargo test after each branch merge (not just after all branches). Catches breakage early before merging more branches on top.
- **Parallel verification**: tsc, vitest, and cargo test run concurrently with `&` + `wait` instead of sequentially, saving time during merge verification.
- **Enhanced preflight checks**: Verifies claude CLI availability, tmux (if WATCH=1), and merge target branch viability before launching agents.
- **Stage-level timeouts**: `MAX_STAGE_DURATION` (default 1800s) kills stalled agents after the configured duration.
- **Cleanup command**: `./scripts/launch-phase.sh <config> cleanup` removes all phase worktrees and branches.
- **Code review round cap**: Supervisor prompt caps review-fix-review loop at 3 rounds. Beyond that, adds `needs-human-review` label.
- **Review deduplication**: Re-triggered reviews include previous review comments so the reviewer can skip already-fixed issues.

### Files Changed

- `scripts/lib/merge.sh` — `run_parallel_verification()`, per-branch verify in `do_merge()`
- `scripts/lib/stage.sh` — enhanced `preflight_check()`, stage timeout watchdog
- `scripts/launch-phase.sh` — `cleanup_phase()`, `MAX_STAGE_DURATION` default, CLI dispatch
- `docs/prompts/supervisor.md` — review caps, cleanup command, per-branch verify docs
- `docs/multi-agent-guide.md` — new sections: per-branch verify, timeouts, cleanup
- `.claude/skills/multi-agent-orchestration/SKILL.md` — updated architecture + lessons learned

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run test` passes (206 tests)
- [ ] `bash -n scripts/launch-phase.sh` passes (syntax check)
- [ ] `bash -n scripts/lib/merge.sh` passes (syntax check)
- [ ] `bash -n scripts/lib/stage.sh` passes (syntax check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)