### PR TITLE
docs: require merge verification before worktree cleanup

### DIFF
--- a/.claude/worktrees/CLAUDE.md
+++ b/.claude/worktrees/CLAUDE.md
@@ -21,8 +21,12 @@ It does NOT apply to CI/workflow agents.
 ## Worktree Lifecycle
 - You are working in a worktree. All git operations (commit, push, rebase) happen here.
 - If you find stale worktrees from crashed agents: `git worktree prune`
-- **Clean up when done (follow this exact order):**
-  1. Run `cd /workspace` as a **standalone Bash call** (not chained with `&&`)
-  2. Then in a **separate** Bash call: `git worktree remove /workspace/.claude/worktrees/<name>`
-  3. Then: `git branch -d <branch>` if the branch still exists
+- **Clean up only after the PR is merged** — the worktree is your only working copy. If you delete it before the merge completes and the merge fails, you have no way to fix and retry. Verify first:
+  ```bash
+  gh pr view <number> --json state --jq '.state'   # must be "MERGED"
+  ```
+- **Cleanup order (each step is a separate Bash call — never chain with `&&`):**
+  1. `cd /workspace`
+  2. `git worktree remove /workspace/.claude/worktrees/<name>`
+  3. `git branch -d <branch>` (if it still exists)
   - **Why separate calls**: If `cd` is chained with `&&` and a later command fails, the Bash tool does not persist the directory change. The CWD remains pointed at the deleted worktree and all subsequent Bash calls fail — this is unrecoverable in the current session.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Use Grep/Glob/Read for: string literals, config keys, file discovery, understand
   - Create: `git worktree add /workspace/.claude/worktrees/<name> -b <branch>`
   - Work entirely within that directory — all git operations (commit, push) happen there
   - `/workspace` must always stay on `main` — it is the shared base for all worktrees
-  - **Clean up when done** (mandatory): see `.claude/worktrees/CLAUDE.md` for the exact cleanup procedure — stale worktrees leak disk and block branch deletion
+  - **Clean up after PR is merged** (mandatory): verify merge succeeded before deleting worktrees — see `.claude/worktrees/CLAUDE.md` for the exact procedure. Stale worktrees leak disk and block branch deletion, but premature deletion loses your ability to fix a failed merge.
 - Do NOT add features, refactoring, or "improvements" beyond what was requested.
 - Write failing tests before implementation when feasible (unit, integration — not E2E requiring deployment). Let the test define the expected behavior, then make it pass.
 - Rebase on main regularly during development (`git fetch origin && git rebase origin/main`). Always rebase and re-verify before creating a PR — the branch must pass against current HEAD, not a stale base.

--- a/docs/prompts/supervisor.md
+++ b/docs/prompts/supervisor.md
@@ -141,7 +141,14 @@ Once the code review finds no issues:
    gh pr merge <number> --squash --delete-branch
    ```
 
-3. Clean up any remaining worktrees (**each command must be a separate Bash call** — never chain `cd` with `&&`):
+3. **Verify the merge succeeded** before cleaning up anything:
+   ```bash
+   gh pr view <number> --json state --jq '.state'
+   ```
+   - If `MERGED` → proceed to cleanup
+   - If not merged → do NOT delete worktrees. Diagnose the failure, fix, and retry the merge. The worktree is your only working copy of the branch.
+
+4. Clean up any remaining worktrees (**each command must be a separate Bash call** — never chain `cd` with `&&`):
    ```bash
    # The merge worktree is cleaned up automatically by create-pr.
    # Only clean up manually if worktrees remain (e.g., from review-fix work):
@@ -153,7 +160,7 @@ Once the code review finds no issues:
    git worktree prune
    ```
 
-4. Update main (separate Bash call after cd):
+5. Update main (separate Bash call after cd):
    ```bash
    # Bash call 1:
    cd /workspace


### PR DESCRIPTION
## Summary
- Agents were deleting worktrees after PR creation, not after merge confirmation. If the merge fails, the worktree is gone and retry is impossible.
- Adds an explicit "verify merge succeeded" step (`gh pr view --json state`) between `gh pr merge` and worktree cleanup in supervisor.md
- Updates `.claude/worktrees/CLAUDE.md` and `CLAUDE.md` to clarify cleanup happens only after the PR is confirmed merged

## Test plan
- [ ] Review supervisor.md step numbering (now 5 steps instead of 4)
- [ ] Verify `.claude/worktrees/CLAUDE.md` cleanup instructions include merge check
- [ ] Verify `CLAUDE.md` worktree bullet reflects the updated guidance

🤖 Generated with [Claude Code](https://claude.ai/code)