### PR TITLE
docs: add rebase-reverify-rereview step before merge in supervisor

### DIFF
--- a/docs/prompts/supervisor.md
+++ b/docs/prompts/supervisor.md
@@ -150,7 +150,8 @@ Once the code review finds no issues:
    gh pr view <number> --json mergeable --jq '.mergeable'
    ```
    - If `MERGEABLE` → proceed to merge
-   - If `CONFLICTING` → rebase onto main, resolve conflicts, reverify (`./scripts/full-verify.sh` or at minimum `bash -n` for scripts + `npx tsc --noEmit` for TS), force-push, then re-run the code review loop (Step 4). Do NOT merge without reverifying and re-reviewing after conflict resolution.
+   - If `UNKNOWN` → wait 10 seconds and re-check (GitHub hasn't computed merge status yet)
+   - If `CONFLICTING` → rebase onto main in the merge worktree, resolve conflicts, reverify (`./scripts/full-verify.sh` or at minimum `bash -n` for scripts + `npx tsc --noEmit` for TS), force-push, then re-run the code review loop (Step 4). Do NOT merge without reverifying and re-reviewing after conflict resolution.
 
 3. Merge the PR:
    ```bash


### PR DESCRIPTION
## Summary
- Adds step 2 to supervisor Step 5: check `gh pr view --json mergeable` before attempting merge
- If CONFLICTING: rebase, reverify, force-push, re-run code review loop (Step 4)
- Prevents conflict resolution from introducing unreviewed/unverified bugs
- Renumbers subsequent steps (3-6)

## Test plan
- [ ] Verify step numbering is sequential (1-6) in Step 5
- [ ] Verify the rebase instruction references Step 4 correctly

🤖 Generated with [Claude Code](https://claude.ai/code)