### PR TITLE
docs: add worktree ownership rules and safety hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,10 @@
           {
             "type": "command",
             "command": "node -e \"const d=JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')); const f=d.tool_input?.file_path||''; if(/package-lock\\.json|src\\/wasm\\/scheduler\\/|\\.env/.test(f)){console.log(JSON.stringify({decision:'block',reason:'Protected file: '+f}))}\""
+          },
+          {
+            "type": "command",
+            "command": "node -e \"const d=JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')); const f=d.tool_input?.file_path||''; if(f.startsWith('/workspace/')&&!f.startsWith('/workspace/.claude/worktrees/')){console.log(JSON.stringify({decision:'block',reason:'Do not edit files directly on main in /workspace. Create a worktree first: git worktree add /workspace/.claude/worktrees/<name> -b <branch>'}))}\""
           }
         ]
       },
@@ -26,6 +30,10 @@
           {
             "type": "command",
             "command": "node -e \"const d=JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')); const c=d.tool_input?.command||''; if(/git\\s+(checkout|switch)/.test(c)&&!/--\\s/.test(c)&&!/worktree/.test(c)){console.log(JSON.stringify({decision:'block',reason:'Do not use git checkout/switch in /workspace. Use a worktree: git worktree add /workspace/.claude/worktrees/<name> -b <branch>'}))}\""
+          },
+          {
+            "type": "command",
+            "command": "node -e \"const d=JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')); const c=d.tool_input?.command||''; if(/git\\s+worktree\\s+(remove|prune)/.test(c)){console.log(JSON.stringify({decision:'block',reason:'Worktree removal blocked. Only remove worktrees you created, and only after your PR is merged. Never remove or prune other agents worktrees.'}))}\""
           }
         ]
       }

--- a/.claude/worktrees/CLAUDE.md
+++ b/.claude/worktrees/CLAUDE.md
@@ -14,14 +14,15 @@ It does NOT apply to CI/workflow agents.
 
 ## Parallel Agent Awareness
 - Other agents may be running concurrently in sibling worktrees.
+- **Never remove a worktree you did not create.** Other agents' worktrees may be in active use — even if they look stale. Only clean up your own worktree, and only after your PR is merged. Only the user can authorize removal of other worktrees.
 - Never modify `/workspace` directly — it must stay on `main`.
 - If you need to read another agent's in-progress work, look in `/workspace/.claude/worktrees/`.
 - Coordinate via files in the repo (e.g. `.agent-status.json`), not by switching branches.
 
 ## Worktree Lifecycle
 - You are working in a worktree. All git operations (commit, push, rebase) happen here.
-- If you find stale worktrees from crashed agents: `git worktree prune`
-- **Clean up only after the PR is merged** — the worktree is your only working copy. If you delete it before the merge completes and the merge fails, you have no way to fix and retry. Verify first:
+- **Never remove worktrees you did not create** — another agent may be using them. Do not run `git worktree prune` or `git worktree remove` on others' worktrees unless the user explicitly asks.
+- **Clean up your own worktree only after its PR is merged** — the worktree is your only working copy. If you delete it before the merge completes and the merge fails, you have no way to fix and retry. Verify first:
   ```bash
   gh pr view <number> --json state --jq '.state'   # must be "MERGED"
   ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,8 @@ Use Grep/Glob/Read for: string literals, config keys, file discovery, understand
   - Create: `git worktree add /workspace/.claude/worktrees/<name> -b <branch>`
   - Work entirely within that directory — all git operations (commit, push) happen there
   - `/workspace` must always stay on `main` — it is the shared base for all worktrees
-  - **Clean up after PR is merged** (mandatory): verify merge succeeded before deleting worktrees — see `.claude/worktrees/CLAUDE.md` for the exact procedure. Stale worktrees leak disk and block branch deletion, but premature deletion loses your ability to fix a failed merge.
+  - **Only clean up worktrees you created.** Never remove, prune, or modify another agent's worktree — it may be in active use. Only the user can authorize removal of worktrees you did not create.
+  - **Clean up your own worktree only after its PR is merged** (mandatory): verify merge succeeded first — see `.claude/worktrees/CLAUDE.md` for the exact procedure. Premature deletion loses your ability to fix a failed merge.
 - Do NOT add features, refactoring, or "improvements" beyond what was requested.
 - Write failing tests before implementation when feasible (unit, integration — not E2E requiring deployment). Let the test define the expected behavior, then make it pass.
 - Rebase on main regularly during development (`git fetch origin && git rebase origin/main`). Always rebase and re-verify before creating a PR — the branch must pass against current HEAD, not a stale base.


### PR DESCRIPTION
## Summary

- Adds three layers of protection to prevent agents from removing worktrees they didn't create:
  1. **CLAUDE.md rules**: Explicit "only clean up worktrees you created" in both root and worktree CLAUDE.md
  2. **PreToolUse hook**: Blocks `git worktree remove` and `git worktree prune` commands, forcing agents to pause (user can still approve)
  3. **PreToolUse hook**: Blocks Edit/Write to `/workspace/` files that aren't in a worktree path, preventing direct edits to main

## Test plan

- [x] `git worktree remove` command is blocked by hook
- [x] `git worktree prune` command is blocked by hook
- [x] Edit to `/workspace/CLAUDE.md` is blocked by hook
- [x] Edit to `/workspace/.claude/worktrees/*/CLAUDE.md` is allowed by hook
- [x] Settings JSON parses correctly

🤖 Generated with [Claude Code](https://claude.ai/code)