### PR TITLE
docs: fix merge command and cleanup order for worktrees

### DIFF
--- a/.claude/worktrees/CLAUDE.md
+++ b/.claude/worktrees/CLAUDE.md
@@ -10,7 +10,7 @@ It does NOT apply to CI/workflow agents.
 4. Trigger code review: use the `/code-review` skill with the PR number.
 5. Fix every issue the review finds, commit, and re-trigger review. Loop until clean.
 6. Once there are no issues, post a comment on the PR summarizing what changed and your reasoning for the approach.
-7. Merge to main: `gh pr merge --squash --delete-branch`.
+7. Merge to main: `gh pr merge --squash` (do NOT use `--delete-branch` — it fails when the worktree still holds the branch).
 
 ## Parallel Agent Awareness
 - Other agents may be running concurrently in sibling worktrees.
@@ -22,12 +22,11 @@ It does NOT apply to CI/workflow agents.
 ## Worktree Lifecycle
 - You are working in a worktree. All git operations (commit, push, rebase) happen here.
 - **Never remove worktrees you did not create** — another agent may be using them. Do not run `git worktree prune` or `git worktree remove` on others' worktrees unless the user explicitly asks.
-- **Clean up your own worktree only after its PR is merged** — the worktree is your only working copy. If you delete it before the merge completes and the merge fails, you have no way to fix and retry. Verify first:
-  ```bash
-  gh pr view <number> --json state --jq '.state'   # must be "MERGED"
-  ```
+- **Clean up your own worktree only after its PR is merged** — the worktree is your only working copy. If you delete it before the merge completes and the merge fails, you have no way to fix and retry.
 - **Cleanup order (each step is a separate Bash call — never chain with `&&`):**
-  1. `cd /workspace`
-  2. `git worktree remove /workspace/.claude/worktrees/<name>`
-  3. `git branch -d <branch>` (if it still exists)
+  1. Verify merge: `gh pr view <number> --json state --jq '.state'` — must be `"MERGED"`
+  2. `cd /workspace`
+  3. `git worktree remove /workspace/.claude/worktrees/<name>`
+  4. `git branch -d <branch>` (if it still exists)
   - **Why separate calls**: If `cd` is chained with `&&` and a later command fails, the Bash tool does not persist the directory change. The CWD remains pointed at the deleted worktree and all subsequent Bash calls fail — this is unrecoverable in the current session.
+  - **Why no `--delete-branch` on merge**: `gh pr merge --squash --delete-branch` tries to delete the local branch while the worktree still holds it, causing an error. Always merge without `--delete-branch` and delete the branch manually after removing the worktree.


### PR DESCRIPTION
## Summary

- Removes `--delete-branch` from `gh pr merge` in the PR and Merge Workflow — it fails with `Cannot delete branch checked out at worktree` when the worktree still holds the branch
- Consolidates the verify-merge step into the cleanup order (was previously a separate step + duplicate in cleanup)
- Adds an explanation of why `--delete-branch` breaks with active worktrees

This was discovered when PR #41's merge errored because `--delete-branch` tried to delete the branch while the worktree still existed.

## Test plan

- [x] Verified the issue: `gh pr merge --squash --delete-branch` fails when worktree holds the branch
- [x] Verified the fix: merge without `--delete-branch`, then remove worktree, then delete branch manually

🤖 Generated with [Claude Code](https://claude.ai/code)