### PR TITLE
docs: subagent delegation guidance for orchestrated agents

### DIFF
--- a/.claude/skills/multi-agent-orchestration/SKILL.md
+++ b/.claude/skills/multi-agent-orchestration/SKILL.md
@@ -64,6 +64,24 @@ Every group prompt should include in its Error Handling section:
 - The calculation rule from CLAUDE.md: agents must NEVER do mental math or date arithmetic — use `node -e`, `python3 -c`, `date -d` with standard libraries (`date-fns`, Python stdlib). Prefer standard library functions over project wrappers.
 - Progress tracking in pipe-delimited format: `TASK_ID | STATUS | ISO_TIMESTAMP | MESSAGE`
 
+## Subagent Delegation in Orchestrated Agents
+Orchestrated agents (spawned by `launch-phase.sh`) are full Claude Code sessions and **can use the Agent tool** to delegate to subagents defined in `.claude/agents/`. The agent definitions are visible from worktrees because worktrees share the repo's file content.
+
+### Available subagents
+- **codebase-explorer** (haiku, 20 turns): Delegate initial file investigation before editing. Preserves the orchestrated agent's context window. Read-only — cannot modify files.
+- **rust-scheduler** (sonnet, 40 turns): Delegate Rust scheduling engine work in `crates/scheduler/`. Can read, edit, write, and run cargo tests.
+- **verify-and-diagnose** (sonnet, 30 turns): Delegate verification (tsc, vitest, cargo test, lint-agent-paths). Returns a structured pass/fail report. Default is verify-only; include "fix" in the prompt for verify-and-fix mode.
+
+### When to delegate
+- **Exploration**: Use `codebase-explorer` before editing unfamiliar code. Saves ~40K tokens of context vs reading files directly.
+- **Verification**: Use `verify-and-diagnose` instead of running tsc/vitest/cargo inline. Gets structured diagnosis without polluting the agent's context with raw test output.
+- **Rust work**: Use `rust-scheduler` when the group's tasks include scheduling engine changes.
+
+### Constraints
+- Subagents have `disallowedTools: Agent` — they cannot spawn further subagents (no recursion).
+- Subagent turns/tokens count against the parent agent's `--max-budget-usd`. If a group prompt will use subagents heavily, increase the budget: `DEFAULT_MAX_BUDGET=15 ./scripts/launch-phase.sh <config> stage N`
+- Subagents inherit the worktree's working directory. All relative paths in structure maps resolve correctly.
+
 ## Lessons Learned
 - **Claude output modes matter**: `-p` produces sparse text-only output (no thinking blocks, no tool-use panels). Interactive mode (no `-p`) produces full rich TUI but does NOT auto-exit — claude waits for more input. Solution: WATCH mode runs claude interactively in tmux, and the prompt instructs claude to exit when done.
 - **WATCH mode requires tmux**: Script must check `command -v tmux` and fail fast. Without this guard, tmux commands silently fail and the polling loop hangs forever.

--- a/docs/multi-agent-guide.md
+++ b/docs/multi-agent-guide.md
@@ -175,6 +175,39 @@ Prompts live in `docs/prompts/<phaseN>/` as standalone files (one per group). Ea
 - Instructs the agent to skip plan mode and execute without confirmation
 - Includes retry context so restarted agents resume where they left off
 
+## Subagent Delegation
+
+Orchestrated agents are full Claude Code sessions and can use the **Agent tool** to delegate
+work to subagents defined in `.claude/agents/`. Subagent definitions are visible from worktrees
+because worktrees share the repo's file content.
+
+**Available subagents:**
+| Subagent | Model | Turns | Best for | Can modify files? |
+|----------|-------|-------|----------|-------------------|
+| `codebase-explorer` | haiku | 20 | Initial file investigation before editing | No (read-only) |
+| `rust-scheduler` | sonnet | 40 | Scheduling engine work in `crates/scheduler/` | Yes |
+| `verify-and-diagnose` | sonnet | 30 | Running tsc/vitest/cargo test with structured diagnosis | Default no; yes with "fix" in prompt |
+
+**When to use:**
+- Use `codebase-explorer` before editing unfamiliar code — saves ~40K tokens of context
+  vs reading files directly in the main agent.
+- Use `verify-and-diagnose` instead of running test suites inline — gets structured
+  pass/fail reports without raw test output in the agent's context.
+- Use `rust-scheduler` when the group's tasks include `crates/scheduler/` changes.
+
+**Budget considerations:**
+Subagent turns/tokens count against the parent agent's `--max-budget-usd` (default $10).
+If prompts will delegate heavily, increase the budget:
+```bash
+DEFAULT_MAX_BUDGET=15 ./scripts/launch-phase.sh <config> stage N
+```
+
+**Constraints:**
+- Subagents have `disallowedTools: Agent` — no recursive delegation.
+- Subagents inherit the worktree's working directory; all paths resolve correctly.
+- File scope rules still apply: subagents should only modify files listed in the
+  parent prompt's `scope.modify` section.
+
 ## Validation Prompt
 
 The validation prompt (e.g., `docs/prompts/phase12/validate.md`) runs after merge. It:


### PR DESCRIPTION
## Summary

- Document how orchestrated agents (spawned by `launch-phase.sh`) can delegate to subagents via the Agent tool
- Add subagent delegation section to `docs/multi-agent-guide.md` with table of available subagents, when to use each, budget considerations, and constraints
- Add matching section to `.claude/skills/multi-agent-orchestration/SKILL.md` for skill-based discovery

Key points documented:
- Orchestrated agents are full Claude Code sessions with Agent tool access
- `.claude/agents/` definitions are visible from worktrees (shared repo content)
- Subagents can't recurse (`disallowedTools: Agent`)
- Budget increases may be needed when delegating (`DEFAULT_MAX_BUDGET=15`)
- File scope rules still apply to subagent modifications

## Test plan

- [x] Documentation accuracy: subagent definitions verified to exist and match described capabilities
- [x] Worktree path resolution: verified all relative paths resolve correctly from worktrees
- [x] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)