### PR TITLE
fix: address code review findings from orchestration PR #49

### DIFF
--- a/scripts/lib/merge.sh
+++ b/scripts/lib/merge.sh
@@ -71,7 +71,7 @@ Do NOT enter plan mode. Do NOT ask for confirmation. Fix the conflicts and commi
     cat > "$wrapper" <<WRAPPER
 #!/usr/bin/env bash
 cd "${MERGE_WORKTREE}"
-claude --dangerously-skip-permissions --max-turns "${MAX_TURNS:-$DEFAULT_MAX_TURNS}" --max-budget-usd "${MAX_BUDGET:-$DEFAULT_MAX_BUDGET}" -p "\$(cat '$fix_prompt_file')"
+cat '${fix_prompt_file}' | claude --dangerously-skip-permissions --max-turns "${MAX_TURNS:-$DEFAULT_MAX_TURNS}" --max-budget-usd "${MAX_BUDGET:-$DEFAULT_MAX_BUDGET}" -p -
 echo \$? > "$exitcode_file"
 WRAPPER
     chmod +x "$wrapper"

--- a/scripts/lib/tmux-supervisor.sh
+++ b/scripts/lib/tmux-supervisor.sh
@@ -217,6 +217,8 @@ tmux_kill_agent() {
 #
 # Usage: tmux_wait_stage <session> <log_dir> <timeout_seconds> <groups...>
 # Polls every 10 seconds. Returns 0 if all succeeded, 1 if any failed.
+# Stall detection: kills agents whose log is unchanged for AGENT_STALL_THRESHOLD seconds (default 300).
+# Timeout: kills all remaining agents after <timeout_seconds>.
 tmux_wait_stage() {
   local session="$1"
   local log_dir="$2"
@@ -239,10 +241,11 @@ tmux_wait_stage() {
     local all_done=true
     local any_failed=false
 
+    # Cache status per group to avoid duplicate tmux_agent_status calls
+    declare -A _cached_status
     for group in "${groups[@]}"; do
-      local status
-      status=$(tmux_agent_status "$session" "$group" "${log_dir}/${group}.log")
-      case "$status" in
+      _cached_status["$group"]=$(tmux_agent_status "$session" "$group" "${log_dir}/${group}.log")
+      case "${_cached_status[$group]}" in
         running|not_started) all_done=false ;;
         failed) any_failed=true ;;
       esac
@@ -260,9 +263,7 @@ tmux_wait_stage() {
 
     # Stall detection: check log file growth for running agents
     for group in "${groups[@]}"; do
-      local status
-      status=$(tmux_agent_status "$session" "$group" "${log_dir}/${group}.log")
-      if [[ "$status" == "running" ]]; then
+      if [[ "${_cached_status[$group]}" == "running" ]]; then
         local current_size
         current_size=$(stat -c %s "${log_dir}/${group}.log" 2>/dev/null || echo 0)
         if [[ "$current_size" != "${_last_sizes[$group]}" ]]; then

--- a/scripts/lib/watch.sh
+++ b/scripts/lib/watch.sh
@@ -1,20 +1,22 @@
 #!/usr/bin/env bash
 # scripts/lib/watch.sh — WATCH mode: tmux-based interactive agent output
 #
-# WATCH mode runs agents in tmux windows with full rich TUI output.
-# Uses pipe-pane for log capture and idle monitor for auto-exit detection.
+# WATCH mode runs agents in tmux windows with visible output.
+# - Agents: interactive mode with pipe-pane for log capture + idle monitor for auto-exit
+# - Validation: pipe mode (cat | claude -p - | tee) for reliable exit codes + wall-clock timeout
 #
 # Lessons learned:
-# 1. Claude interactive (no -p flag) = full rich TUI output
-# 2. tmux pipe-pane captures logs WITHOUT breaking TUI rendering
-# 3. Idle monitor (background child) kills claude when output stabilizes
-# 4. tmux send-keys (not command string) keeps shell alive for scrollback
-# 5. Pre-trust workspace via quick -p dry run (interactive shows trust dialog)
-# 6. Explicit -t TMUX_TARGET for pipe-pane (avoids wrong-pane bug)
+# 1. Agents use interactive mode (no -p) for full rich TUI; validation uses -p for auto-exit
+# 2. Agent logs: tmux pipe-pane captures output WITHOUT breaking TUI rendering
+# 3. Validation logs: tee in pipeline (pipe-pane not needed since -p mode has no TUI)
+# 4. Idle monitor (background child) kills agents when output stabilizes
+# 5. tmux send-keys (not command string) keeps shell alive for scrollback
+# 6. Pre-trust workspace via quick -p dry run (interactive shows trust dialog)
+# 7. Explicit -t TMUX_TARGET for pipe-pane (avoids wrong-pane bug)
+# 8. YAML frontmatter --- in prompts is parsed as CLI flags — use pipe mode to avoid
 
 AGENT_IDLE_THRESHOLD="${IDLE_THRESHOLD:-30}"  # seconds of stable log before killing agent
 VALIDATE_IDLE_THRESHOLD="${IDLE_THRESHOLD:-120}"  # validation needs longer (runs tsc/vitest/cargo)
-VALIDATE_TIMEOUT="${VALIDATE_TIMEOUT:-600}"  # wall-clock timeout per validation attempt (seconds)
 
 # Build wrapper script for a WATCH mode agent.
 # Returns path to the wrapper script via stdout.
@@ -305,6 +307,7 @@ watch_validate() {
   local prompt_file="${WORKSPACE}/${PROMPTS_DIR}/validate.md"
   local max_attempts="${VALIDATE_MAX_ATTEMPTS:-3}"
   local exitcode_file="${LOG_DIR}/validate.exit"
+  local validate_timeout="${VALIDATE_TIMEOUT:-600}"
 
   if [[ ! -f "$prompt_file" ]]; then
     warn "No validation prompt found at $prompt_file — skipping."
@@ -431,8 +434,8 @@ VALIDATE_WRAPPER
       local now_v
       now_v=$(date +%s)
       local elapsed_v=$(( now_v - validate_start ))
-      if [[ $elapsed_v -ge $VALIDATE_TIMEOUT ]]; then
-        warn "Validation attempt ${attempt} timed out after ${VALIDATE_TIMEOUT}s"
+      if [[ $elapsed_v -ge $validate_timeout ]]; then
+        warn "Validation attempt ${attempt} timed out after ${validate_timeout}s"
         tmux kill-session -t "${tmux_session}" 2>/dev/null || true
         echo "1" > "$exitcode_file"
         break


### PR DESCRIPTION
## Summary
- Switch `resolve_merge_conflicts` WATCH mode from positional arg (`claude -p "$(cat ...)"`) to pipe mode (`cat | claude -p -`) — same fix applied to validation in #49, now consistent across all wrappers
- Update `watch.sh` header comments to accurately describe dual logging strategy: agents use interactive+pipe-pane, validation uses pipe mode+tee
- Update `tmux_wait_stage()` docstring to document stall detection and kill behavior
- Cache `tmux_agent_status` results per poll iteration to avoid duplicate tmux queries
- Move `VALIDATE_TIMEOUT` from file-level global to local scope in `watch_validate()` for consistency with `validate.sh`

## Test plan
- [x] `bash -n` syntax check passes on all 3 modified scripts
- [ ] Review diff for correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)