### PR TITLE
fix: cached status in timeout + PIPESTATUS in merge wrapper

### DIFF
--- a/scripts/lib/merge.sh
+++ b/scripts/lib/merge.sh
@@ -71,8 +71,8 @@ Do NOT enter plan mode. Do NOT ask for confirmation. Fix the conflicts and commi
     cat > "$wrapper" <<WRAPPER
 #!/usr/bin/env bash
 cd "${MERGE_WORKTREE}"
-cat '${fix_prompt_file}' | claude --dangerously-skip-permissions --max-turns "${MAX_TURNS:-$DEFAULT_MAX_TURNS}" --max-budget-usd "${MAX_BUDGET:-$DEFAULT_MAX_BUDGET}" -p -
-echo \$? > "$exitcode_file"
+set -o pipefail && cat '${fix_prompt_file}' | claude --dangerously-skip-permissions --max-turns "${MAX_TURNS:-$DEFAULT_MAX_TURNS}" --max-budget-usd "${MAX_BUDGET:-$DEFAULT_MAX_BUDGET}" -p -
+echo \${PIPESTATUS[1]:-\$?} > "$exitcode_file"
 WRAPPER
     chmod +x "$wrapper"
 

--- a/scripts/lib/tmux-supervisor.sh
+++ b/scripts/lib/tmux-supervisor.sh
@@ -231,7 +231,7 @@ tmux_wait_stage() {
   start=$(date +%s)
 
   # Track log sizes for stall detection
-  declare -A _last_sizes _last_change
+  declare -A _last_sizes _last_change _cached_status
   for group in "${groups[@]}"; do
     _last_sizes["$group"]=0
     _last_change["$group"]=$start
@@ -242,7 +242,6 @@ tmux_wait_stage() {
     local any_failed=false
 
     # Cache status per group to avoid duplicate tmux_agent_status calls
-    declare -A _cached_status
     for group in "${groups[@]}"; do
       _cached_status["$group"]=$(tmux_agent_status "$session" "$group" "${log_dir}/${group}.log")
       case "${_cached_status[$group]}" in
@@ -282,9 +281,7 @@ tmux_wait_stage() {
     if [[ $elapsed -ge $timeout ]]; then
       echo "TIMEOUT after ${timeout}s — killing remaining agents"
       for group in "${groups[@]}"; do
-        local status
-        status=$(tmux_agent_status "$session" "$group" "${log_dir}/${group}.log")
-        if [[ "$status" == "running" ]]; then
+        if [[ "${_cached_status[$group]}" == "running" ]]; then
           tmux_kill_agent "$session" "$group" "${log_dir}/${group}.log"
         fi
       done


### PR DESCRIPTION
## Summary
- Move `declare -A _cached_status` before the `while` loop alongside other associative arrays, avoiding re-declaration each iteration
- Use `_cached_status[$group]` in the timeout block instead of calling `tmux_agent_status` again (consistent with stall detection block)
- Use `PIPESTATUS[1]` in merge.sh WATCH wrapper to capture claude's exit code explicitly, matching the pattern used in watch.sh validation

## Test plan
- [x] `bash -n` syntax check passes on both modified scripts
- [ ] Review diff for correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)