### PR TITLE
fix: restore statusline config in settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,8 @@
 {
+  "statusLine": {
+    "type": "command",
+    "command": "bash ~/.claude/statusline.sh 2>/dev/null"
+  },
   "enabledPlugins": {
     "rust-analyzer-lsp@claude-plugins-official": true,
     "typescript-lsp@claude-plugins-official": true,


### PR DESCRIPTION
## Summary
- Restores the `statusLine` entry in `.claude/settings.json` that was lost during a rebase
- Points to `~/.claude/statusline.sh` (user-level, silent fallback via `2>/dev/null`)

## Test plan
- [ ] Verify statusline renders in Claude Code after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)